### PR TITLE
Update functions runtime to v4

### DIFF
--- a/AzWarrantyUpdaterAutotask.json
+++ b/AzWarrantyUpdaterAutotask.json
@@ -99,7 +99,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "AutotaskHostName",

--- a/AzWarrantyUpdaterCWM.json
+++ b/AzWarrantyUpdaterCWM.json
@@ -99,7 +99,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "CWMHostname",

--- a/AzWarrantyUpdaterDRMM.json
+++ b/AzWarrantyUpdaterDRMM.json
@@ -92,7 +92,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "DattoAPIURL",

--- a/AzWarrantyUpdaterHudu.json
+++ b/AzWarrantyUpdaterHudu.json
@@ -85,7 +85,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "HuduHostname",

--- a/AzWarrantyUpdaterITglue.json
+++ b/AzWarrantyUpdaterITglue.json
@@ -85,7 +85,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "ItglueAPIKey",

--- a/AzWarrantyUpdaterNAble.json
+++ b/AzWarrantyUpdaterNAble.json
@@ -85,7 +85,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~3"
+                            "value": "~4"
                         },
                         {
                             "name": "NableHostname",


### PR DESCRIPTION
Version 3 of the azure functions runtime is being retired. Updated all AzWarranty scripts to use the newer runtime v4.